### PR TITLE
DDCYLS-3333 Added crypto functionality for previous encryption key

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -19,15 +19,13 @@ package config
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 
-@Singleton
-class AppConfig @Inject()(config: Configuration) {
+import scala.util.Try
 
-  val appName: String = config.get[String]("appName")
+@Singleton
+class AppConfig @Inject()(val config: Configuration) {
 
   lazy val cacheTtl: Int = config.get[Int]("mongodb.timeToLiveInDays")
 
-  val mongoEncryptionKey = config.get[String]("mongodb.encryption.key")
-
-  val updateRecordsOnStartUp = config.get[Boolean]("mongodb.updateLastUpdated")
-
+  val mongoEncryptionKey: String = config.get[String]("mongodb.encryption.key")
+  val previousMongoEncryptionKey: Option[String] = Try(config.get[String]("mongodb.encryption.previousKey")).toOption
 }

--- a/app/crypto/FullDisclosureEncrypter.scala
+++ b/app/crypto/FullDisclosureEncrypter.scala
@@ -27,56 +27,43 @@ class FullDisclosureEncrypter @Inject()(
   notificationEncrypter: NotificationEncrypter
 ) {
 
-  def encryptFullDisclosure(
-    fullDisclosure: FullDisclosure,
-    sessionId: String,
-    key: String): EncryptedFullDisclosure = {
-
+  def encryptFullDisclosure(fullDisclosure: FullDisclosure, sessionId: String): EncryptedFullDisclosure =
     EncryptedFullDisclosure(
       userId = fullDisclosure.userId,
       submissionId = fullDisclosure.submissionId,
       lastUpdated = fullDisclosure.lastUpdated,
       created = fullDisclosure.created,
       metadata = fullDisclosure.metadata,
-      caseReference = encryptCaseReference(fullDisclosure.caseReference, sessionId, key),
-      personalDetails = notificationEncrypter.encryptPersonalDetails(fullDisclosure.personalDetails, sessionId, key),
+      caseReference = encryptCaseReference(fullDisclosure.caseReference, sessionId),
+      personalDetails = notificationEncrypter.encryptPersonalDetails(fullDisclosure.personalDetails, sessionId),
       onshoreLiabilities = fullDisclosure.onshoreLiabilities,
       offshoreLiabilities = fullDisclosure.offshoreLiabilities,
       otherLiabilities = fullDisclosure.otherLiabilities,
-      reasonForDisclosingNow = encryptReasonForDisclosingNow(fullDisclosure.reasonForDisclosingNow, sessionId, key),
+      reasonForDisclosingNow = encryptReasonForDisclosingNow(fullDisclosure.reasonForDisclosingNow, sessionId),
       customerId = fullDisclosure.customerId,
       madeDeclaration = fullDisclosure.madeDeclaration
     )
-  } 
 
-  def decryptFullDisclosure(
-    fullDisclosure: EncryptedFullDisclosure,
-    sessionId: String,
-    key: String): FullDisclosure = {
-
+  def decryptFullDisclosure(fullDisclosure: EncryptedFullDisclosure, sessionId: String): FullDisclosure =
     FullDisclosure(
       userId = fullDisclosure.userId,
       submissionId = fullDisclosure.submissionId,
       lastUpdated = fullDisclosure.lastUpdated,
       created = fullDisclosure.created,
       metadata = fullDisclosure.metadata,
-      caseReference = decryptCaseReference(fullDisclosure.caseReference, sessionId, key),
-      personalDetails = notificationEncrypter.decryptPersonalDetails(fullDisclosure.personalDetails, sessionId, key),
+      caseReference = decryptCaseReference(fullDisclosure.caseReference, sessionId),
+      personalDetails = notificationEncrypter.decryptPersonalDetails(fullDisclosure.personalDetails, sessionId),
       onshoreLiabilities = fullDisclosure.onshoreLiabilities,
       offshoreLiabilities = fullDisclosure.offshoreLiabilities,
       otherLiabilities = fullDisclosure.otherLiabilities,
-      reasonForDisclosingNow = decryptReasonForDisclosingNow(fullDisclosure.reasonForDisclosingNow, sessionId, key),
+      reasonForDisclosingNow = decryptReasonForDisclosingNow(fullDisclosure.reasonForDisclosingNow, sessionId),
       customerId = fullDisclosure.customerId,
       madeDeclaration = fullDisclosure.madeDeclaration
     )
-  }
 
-  def encryptCaseReference(
-    caseReference: CaseReference,
-    sessionId: String,
-    key: String): EncryptedCaseReference = {
+  def encryptCaseReference(caseReference: CaseReference, sessionId: String): EncryptedCaseReference = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedCaseReference (
       doYouHaveACaseReference = caseReference.doYouHaveACaseReference,
@@ -84,12 +71,9 @@ class FullDisclosureEncrypter @Inject()(
     )
   } 
 
-  def decryptCaseReference(
-    caseReference: EncryptedCaseReference,
-    sessionId: String,
-    key: String): CaseReference = {
+  def decryptCaseReference(caseReference: EncryptedCaseReference, sessionId: String): CaseReference = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     CaseReference (
       doYouHaveACaseReference = caseReference.doYouHaveACaseReference,
@@ -99,10 +83,10 @@ class FullDisclosureEncrypter @Inject()(
 
   def encryptReasonForDisclosingNow(
     reasonForDisclosingNow: ReasonForDisclosingNow,
-    sessionId: String,
-    key: String): EncryptedReasonForDisclosingNow = {
+    sessionId: String
+  ): EncryptedReasonForDisclosingNow = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedReasonForDisclosingNow(
       reason = reasonForDisclosingNow.reason,
@@ -123,10 +107,10 @@ class FullDisclosureEncrypter @Inject()(
 
   def decryptReasonForDisclosingNow(
     reasonForDisclosingNow: EncryptedReasonForDisclosingNow,
-    sessionId: String,
-    key: String): ReasonForDisclosingNow = {
+    sessionId: String
+  ): ReasonForDisclosingNow = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     ReasonForDisclosingNow(
       reason = reasonForDisclosingNow.reason,
@@ -144,5 +128,4 @@ class FullDisclosureEncrypter @Inject()(
       telephone = reasonForDisclosingNow.telephone.map(d)
     )
   }
-
 }

--- a/app/crypto/NotificationEncrypter.scala
+++ b/app/crypto/NotificationEncrypter.scala
@@ -26,78 +26,55 @@ import java.time.LocalDate
 @Singleton
 class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
 
-  def encryptNotification(
-    notification: Notification,
-    sessionId: String,
-    key: String): EncryptedNotification = {
-
+  def encryptNotification(notification: Notification, sessionId: String): EncryptedNotification =
     EncryptedNotification(
       userId = notification.userId,
       submissionId = notification.submissionId,
       lastUpdated = notification.lastUpdated,
       created = notification.created,
       metadata = notification.metadata,
-      personalDetails = encryptPersonalDetails(notification.personalDetails, sessionId, key),
+      personalDetails = encryptPersonalDetails(notification.personalDetails, sessionId),
       customerId = notification.customerId,
       madeDeclaration = notification.madeDeclaration
     )
-  } 
 
-  def decryptNotification(
-    notification: EncryptedNotification,
-    sessionId: String,
-    key: String): Notification = {
-
+  def decryptNotification(notification: EncryptedNotification, sessionId: String): Notification =
     Notification(
       userId = notification.userId,
       submissionId = notification.submissionId,
       lastUpdated = notification.lastUpdated,
       created = notification.created,
       metadata = notification.metadata,
-      personalDetails = decryptPersonalDetails(notification.personalDetails, sessionId, key),
+      personalDetails = decryptPersonalDetails(notification.personalDetails, sessionId),
       customerId = notification.customerId,
       madeDeclaration = notification.madeDeclaration
     )
-  }
 
-  def encryptPersonalDetails(
-    notification: PersonalDetails,
-    sessionId: String,
-    key: String): EncryptedPersonalDetails = {
-
+  def encryptPersonalDetails(notification: PersonalDetails, sessionId: String): EncryptedPersonalDetails =
     EncryptedPersonalDetails(
-      background = encryptBackground(notification.background, sessionId, key),
-      aboutYou = encryptAboutYou(notification.aboutYou, sessionId, key),
-      aboutTheIndividual = notification.aboutTheIndividual.map(encryptAboutTheIndividual(_, sessionId, key)),
-      aboutTheCompany = notification.aboutTheCompany.map(encryptAboutTheCompany(_, sessionId, key)),
-      aboutTheTrust = notification.aboutTheTrust.map(encryptAboutTheTrust(_, sessionId, key)),
-      aboutTheLLP = notification.aboutTheLLP.map(encryptAboutTheLLP(_, sessionId, key)),
-      aboutTheEstate = notification.aboutTheEstate.map(encryptAboutTheEstate(_, sessionId, key))
+      background = encryptBackground(notification.background, sessionId),
+      aboutYou = encryptAboutYou(notification.aboutYou, sessionId),
+      aboutTheIndividual = notification.aboutTheIndividual.map(encryptAboutTheIndividual(_, sessionId)),
+      aboutTheCompany = notification.aboutTheCompany.map(encryptAboutTheCompany(_, sessionId)),
+      aboutTheTrust = notification.aboutTheTrust.map(encryptAboutTheTrust(_, sessionId)),
+      aboutTheLLP = notification.aboutTheLLP.map(encryptAboutTheLLP(_, sessionId)),
+      aboutTheEstate = notification.aboutTheEstate.map(encryptAboutTheEstate(_, sessionId))
     )
-  } 
 
-  def decryptPersonalDetails(
-    notification: EncryptedPersonalDetails,
-    sessionId: String,
-    key: String): PersonalDetails = {
-
+  def decryptPersonalDetails(notification: EncryptedPersonalDetails, sessionId: String): PersonalDetails =
     PersonalDetails(
-      background = decryptBackground(notification.background, sessionId, key),
-      aboutYou = decryptAboutYou(notification.aboutYou, sessionId, key),
-      aboutTheIndividual = notification.aboutTheIndividual.map(decryptAboutTheIndividual(_, sessionId, key)),
-      aboutTheCompany = notification.aboutTheCompany.map(decryptAboutTheCompany(_, sessionId, key)),
-      aboutTheTrust = notification.aboutTheTrust.map(decryptAboutTheTrust(_, sessionId, key)),
-      aboutTheLLP = notification.aboutTheLLP.map(decryptAboutTheLLP(_, sessionId, key)),
-      aboutTheEstate = notification.aboutTheEstate.map(decryptAboutTheEstate(_, sessionId, key))
+      background = decryptBackground(notification.background, sessionId),
+      aboutYou = decryptAboutYou(notification.aboutYou, sessionId),
+      aboutTheIndividual = notification.aboutTheIndividual.map(decryptAboutTheIndividual(_, sessionId)),
+      aboutTheCompany = notification.aboutTheCompany.map(decryptAboutTheCompany(_, sessionId)),
+      aboutTheTrust = notification.aboutTheTrust.map(decryptAboutTheTrust(_, sessionId)),
+      aboutTheLLP = notification.aboutTheLLP.map(decryptAboutTheLLP(_, sessionId)),
+      aboutTheEstate = notification.aboutTheEstate.map(decryptAboutTheEstate(_, sessionId))
     )
-  }
 
-  def encryptBackground(
-    background: Background,
-    sessionId: String,
-    key: String): EncryptedBackground = {
+  def encryptBackground(background: Background, sessionId: String): EncryptedBackground = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedBackground (
       haveYouReceivedALetter = background.haveYouReceivedALetter,
@@ -112,12 +89,9 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
     )
   } 
 
-  def decryptBackground(
-    background: EncryptedBackground,
-    sessionId: String,
-    key: String): Background = {
+  def decryptBackground(background: EncryptedBackground, sessionId: String): Background = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     Background (
       haveYouReceivedALetter = background.haveYouReceivedALetter,
@@ -132,12 +106,9 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
     )
   }
 
-  def encryptAddress(
-    address: Address,
-    sessionId: String,
-    key: String): EncryptedAddress = {
+  def encryptAddress(address: Address, sessionId: String): EncryptedAddress = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAddress(
       line1 = e(address.line1),
@@ -149,12 +120,9 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
     )
   } 
 
-  def decryptAddress(
-    address: EncryptedAddress,
-    sessionId: String,
-    key: String): Address = {
+  def decryptAddress(address: EncryptedAddress, sessionId: String): Address = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     Address (
       line1 = d(address.line1),
@@ -166,12 +134,9 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
     )
   }
 
-  def encryptAboutYou(
-    aboutYou: AboutYou,
-    sessionId: String,
-    key: String): EncryptedAboutYou = {
+  def encryptAboutYou(aboutYou: AboutYou, sessionId: String): EncryptedAboutYou = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAboutYou (
       fullName = aboutYou.fullName.map(e),
@@ -186,16 +151,13 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
       vatRegNumber = aboutYou.vatRegNumber.map(e),
       registeredForSA = aboutYou.registeredForSA,
       sautr = aboutYou.sautr.map(e),
-      address = aboutYou.address.map(encryptAddress(_, sessionId, key)),
+      address = aboutYou.address.map(encryptAddress(_, sessionId)),
     )
   }
 
-  def decryptAboutYou(
-    aboutYou: EncryptedAboutYou,
-    sessionId: String,
-    key: String): AboutYou = {
+  def decryptAboutYou(aboutYou: EncryptedAboutYou, sessionId: String): AboutYou = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     AboutYou (
       fullName = aboutYou.fullName.map(d),
@@ -210,16 +172,16 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
       vatRegNumber = aboutYou.vatRegNumber.map(d),
       registeredForSA = aboutYou.registeredForSA,
       sautr = aboutYou.sautr.map(d),
-      address = aboutYou.address.map(decryptAddress(_, sessionId, key)),
+      address = aboutYou.address.map(decryptAddress(_, sessionId)),
     )
   }
 
   def encryptAboutTheIndividual(
     aboutTheIndividual: AboutTheIndividual,
-    sessionId: String,
-    key: String): EncryptedAboutTheIndividual = {
+    sessionId: String
+  ): EncryptedAboutTheIndividual = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAboutTheIndividual (
       fullName = aboutTheIndividual.fullName.map(e),
@@ -231,16 +193,16 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
       vatRegNumber = aboutTheIndividual.vatRegNumber.map(e),
       registeredForSA = aboutTheIndividual.registeredForSA,
       sautr = aboutTheIndividual.sautr.map(e),
-      address = aboutTheIndividual.address.map(encryptAddress(_, sessionId, key)),
+      address = aboutTheIndividual.address.map(encryptAddress(_, sessionId)),
     )
   } 
 
   def decryptAboutTheIndividual(
     aboutTheIndividual: EncryptedAboutTheIndividual,
-    sessionId: String,
-    key: String): AboutTheIndividual = {
+    sessionId: String
+  ): AboutTheIndividual = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     AboutTheIndividual (
       fullName = aboutTheIndividual.fullName.map(d),
@@ -252,96 +214,75 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
       vatRegNumber = aboutTheIndividual.vatRegNumber.map(d),
       registeredForSA = aboutTheIndividual.registeredForSA,
       sautr = aboutTheIndividual.sautr.map(d),
-      address = aboutTheIndividual.address.map(decryptAddress(_, sessionId, key)),
+      address = aboutTheIndividual.address.map(decryptAddress(_, sessionId)),
     )
   }
 
-  def encryptAboutTheCompany(
-    aboutTheCompany: AboutTheCompany,
-    sessionId: String,
-    key: String): EncryptedAboutTheCompany = {
+  def encryptAboutTheCompany(aboutTheCompany: AboutTheCompany, sessionId: String): EncryptedAboutTheCompany = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAboutTheCompany (
       name = aboutTheCompany.name.map(e),
       registrationNumber = aboutTheCompany.registrationNumber.map(e),
-      address = aboutTheCompany.address.map(encryptAddress(_, sessionId, key)),
+      address = aboutTheCompany.address.map(encryptAddress(_, sessionId)),
     )
   } 
 
-  def decryptAboutTheCompany(
-    aboutTheCompany: EncryptedAboutTheCompany,
-    sessionId: String,
-    key: String): AboutTheCompany = {
+  def decryptAboutTheCompany(aboutTheCompany: EncryptedAboutTheCompany, sessionId: String): AboutTheCompany = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     AboutTheCompany (
       name = aboutTheCompany.name.map(d),
       registrationNumber = aboutTheCompany.registrationNumber.map(d),
-      address = aboutTheCompany.address.map(decryptAddress(_, sessionId, key)),
+      address = aboutTheCompany.address.map(decryptAddress(_, sessionId)),
     )
   }
 
-  def encryptAboutTheTrust(
-    aboutTheTrust: AboutTheTrust,
-    sessionId: String,
-    key: String): EncryptedAboutTheTrust = {
+  def encryptAboutTheTrust(aboutTheTrust: AboutTheTrust, sessionId: String): EncryptedAboutTheTrust = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAboutTheTrust (
       name = aboutTheTrust.name.map(e),
-      address = aboutTheTrust.address.map(encryptAddress(_, sessionId, key)),
+      address = aboutTheTrust.address.map(encryptAddress(_, sessionId)),
     )
   } 
 
-  def decryptAboutTheTrust(
-    aboutTheTrust: EncryptedAboutTheTrust,
-    sessionId: String,
-    key: String): AboutTheTrust = {
+  def decryptAboutTheTrust(aboutTheTrust: EncryptedAboutTheTrust, sessionId: String): AboutTheTrust = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     AboutTheTrust (
       name = aboutTheTrust.name.map(d),
-      address = aboutTheTrust.address.map(decryptAddress(_, sessionId, key)),
+      address = aboutTheTrust.address.map(decryptAddress(_, sessionId)),
     )
   }
 
-  def encryptAboutTheLLP(
-    aboutTheLLP: AboutTheLLP,
-    sessionId: String,
-    key: String): EncryptedAboutTheLLP = {
+  def encryptAboutTheLLP(aboutTheLLP: AboutTheLLP, sessionId: String): EncryptedAboutTheLLP = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAboutTheLLP (
       name = aboutTheLLP.name.map(e),
-      address = aboutTheLLP.address.map(encryptAddress(_, sessionId, key)),
+      address = aboutTheLLP.address.map(encryptAddress(_, sessionId)),
     )
   } 
 
-  def decryptAboutTheLLP(
-    aboutTheLLP: EncryptedAboutTheLLP,
-    sessionId: String,
-    key: String): AboutTheLLP = {
+  def decryptAboutTheLLP(aboutTheLLP: EncryptedAboutTheLLP, sessionId: String): AboutTheLLP = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     AboutTheLLP (
       name = aboutTheLLP.name.map(d),
-      address = aboutTheLLP.address.map(decryptAddress(_, sessionId, key)),
+      address = aboutTheLLP.address.map(decryptAddress(_, sessionId)),
     )
   }
 
-  def encryptAboutTheEstate(
-    aboutTheEstate: AboutTheEstate,
-    sessionId: String,
-    key: String): EncryptedAboutTheEstate = {
+  def encryptAboutTheEstate(aboutTheEstate: AboutTheEstate, sessionId: String): EncryptedAboutTheEstate = {
 
-    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId, key)
+    def e(field: String): EncryptedValue = crypto.encrypt(field, sessionId)
 
     EncryptedAboutTheEstate (
       fullName = aboutTheEstate.fullName.map(e),
@@ -353,16 +294,13 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
       vatRegNumber = aboutTheEstate.vatRegNumber.map(e),
       registeredForSA = aboutTheEstate.registeredForSA,
       sautr = aboutTheEstate.sautr.map(e),
-      address = aboutTheEstate.address.map(encryptAddress(_, sessionId, key)),
+      address = aboutTheEstate.address.map(encryptAddress(_, sessionId)),
     )
   } 
 
-  def decryptAboutTheEstate(
-    aboutTheEstate: EncryptedAboutTheEstate,
-    sessionId: String,
-    key: String): AboutTheEstate = {
+  def decryptAboutTheEstate(aboutTheEstate: EncryptedAboutTheEstate, sessionId: String): AboutTheEstate = {
 
-    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId, key)
+    def d(field: EncryptedValue): String = crypto.decrypt(field, sessionId)
 
     AboutTheEstate (
       fullName = aboutTheEstate.fullName.map(d),
@@ -374,8 +312,7 @@ class NotificationEncrypter @Inject()(crypto: SecureGCMCipher) {
       vatRegNumber = aboutTheEstate.vatRegNumber.map(d),
       registeredForSA = aboutTheEstate.registeredForSA,
       sautr = aboutTheEstate.sautr.map(d),
-      address = aboutTheEstate.address.map(decryptAddress(_, sessionId, key)),
+      address = aboutTheEstate.address.map(decryptAddress(_, sessionId)),
     )   
   }
-
 }

--- a/app/crypto/SubmissionEncrypter.scala
+++ b/app/crypto/SubmissionEncrypter.scala
@@ -26,21 +26,15 @@ class SubmissionEncrypter @Inject()(
   fullDisclosureEncrypter: FullDisclosureEncrypter
 ) {
 
-  def encryptSubmission(
-    submission: Submission,
-    sessionId: String,
-    key: String): EncryptedSubmission = 
-      submission match {
-        case notification: Notification => notificationEncrypter.encryptNotification(notification, sessionId, key)
-        case disclosure: FullDisclosure => fullDisclosureEncrypter.encryptFullDisclosure(disclosure, sessionId, key)
-      }
+  def encryptSubmission(submission: Submission, sessionId: String): EncryptedSubmission =
+    submission match {
+      case notification: Notification => notificationEncrypter.encryptNotification(notification, sessionId)
+      case disclosure: FullDisclosure => fullDisclosureEncrypter.encryptFullDisclosure(disclosure, sessionId)
+    }
 
-  def decryptSubmission(
-    submission: EncryptedSubmission,
-    sessionId: String,
-    key: String): Submission = 
-      submission match {
-        case notification: EncryptedNotification => notificationEncrypter.decryptNotification(notification, sessionId, key)
-        case disclosure: EncryptedFullDisclosure => fullDisclosureEncrypter.decryptFullDisclosure(disclosure, sessionId, key)
-      }
+  def decryptSubmission(submission: EncryptedSubmission, sessionId: String): Submission =
+    submission match {
+      case notification: EncryptedNotification => notificationEncrypter.decryptNotification(notification, sessionId)
+      case disclosure: EncryptedFullDisclosure => fullDisclosureEncrypter.decryptFullDisclosure(disclosure, sessionId)
+    }
 }

--- a/app/repositories/SubmissionRepository.scala
+++ b/app/repositories/SubmissionRepository.scala
@@ -69,8 +69,6 @@ class SubmissionRepositoryImpl @Inject()(
     extraCodecs = Codecs.playFormatSumCodecs(EncryptedSubmission.format)
   ) with SubmissionRepository {
 
-  private val key = appConfig.mongoEncryptionKey
-
   implicit val instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
 
   def get(userId: String, submissionId: String): Future[Option[Submission]] =
@@ -79,7 +77,7 @@ class SubmissionRepositoryImpl @Inject()(
         Filters.equal("userId", userId),
         Filters.equal("submissionId", submissionId)
       ))
-      .map(encrypter.decryptSubmission(_, userId, key))
+      .map(encrypter.decryptSubmission(_, userId))
       .headOption()
         
   def get(userId: String): Future[Seq[Submission]] =
@@ -87,7 +85,7 @@ class SubmissionRepositoryImpl @Inject()(
       .find(Filters.and(
         Filters.equal("userId", userId)
       ))
-      .map(encrypter.decryptSubmission(_, userId, key))
+      .map(encrypter.decryptSubmission(_, userId))
       .toFuture()
 
   def set(submission: Submission): Future[Boolean] = {
@@ -103,7 +101,7 @@ class SubmissionRepositoryImpl @Inject()(
           Filters.equal("userId", submission.userId),
           Filters.equal("submissionId", submission.submissionId)
         ),
-        replacement = encrypter.encryptSubmission(updatedSubmission, submission.userId, key),
+        replacement = encrypter.encryptSubmission(updatedSubmission, submission.userId),
         options     = ReplaceOptions().upsert(true)
       )
       .toFuture()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -99,7 +99,6 @@ metrics {
 
 auditing {
   enabled = false
-  traceRequests = true
   consumer {
     baseUri {
       host = localhost
@@ -112,7 +111,8 @@ mongodb {
   uri = "mongodb://localhost:27017/digital-disclosure-service-store"
   timeToLiveInDays = 30
   encryption {
-    key = "VqmXp7yigDFxbCUdDdNZVIvbW6RgPNJsliv6swQNCL8="
+    key = "zjWYSlNW79BKWTONyGFQsT7buBcWiiOkx8blzp6LNVw="
+    previousKey = "VqmXp7yigDFxbCUdDdNZVIvbW6RgPNJsliv6swQNCL8="
   }
   updateLastUpdated = false
 }

--- a/it/repositories/SubmissionRepositorySpec.scala
+++ b/it/repositories/SubmissionRepositorySpec.scala
@@ -42,6 +42,8 @@ class SubmissionRepositorySpec extends AnyFreeSpec
 
   private val now: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS)
   private val clock: MutableClock = MutableClock(now)
+  private val secretKey = "zjWYSlNW79BKWTONyGFQsT7buBcWiiOkx8blzp6LNVw="
+  implicit val appConfig: AppConfig = new AppConfig(Configuration("mongodb.encryption.key" -> secretKey))
   private val notificationEncrypter = new NotificationEncrypter(new SecureGCMCipherImpl)
   private val disclosureEncrypter = new FullDisclosureEncrypter(new SecureGCMCipherImpl, notificationEncrypter)
   private val encrypter = new SubmissionEncrypter(notificationEncrypter, disclosureEncrypter)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,21 +1,18 @@
-import play.core.PlayVersion
-import play.sbt.PlayImport._
-import sbt.Keys.libraryDependencies
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "7.15.0"
-  private val hmrcMongoVersion = "1.2.0"
+  private val bootstrapVersion = "7.21.0"
+  private val hmrcMongoVersion = "1.3.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-28"       % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"              % hmrcMongoVersion,
     "org.scala-lang.modules"  %% "scala-xml"                       % "1.3.0",
-    "uk.gov.hmrc"             %% "internal-auth-client-play-28"    % "1.4.0"
+    "uk.gov.hmrc"             %% "internal-auth-client-play-28"    % "1.6.0"
   )
 
-  val test = Seq(
+  val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % bootstrapVersion            % "test, it",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28"    % hmrcMongoVersion            % "test, it",
     "org.scalatestplus"       %% "mockito-3-4"                % "3.2.10.0"                  % "test, it"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.20")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")

--- a/test/uk/gov/hmrc/digitaldisclosureservicestore/crypto/FullDisclosureEncrypterSpec.scala
+++ b/test/uk/gov/hmrc/digitaldisclosureservicestore/crypto/FullDisclosureEncrypterSpec.scala
@@ -16,19 +16,22 @@
 
 package crypto
 
+import config.AppConfig
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.freespec.AnyFreeSpec
-
 import models.disclosure._
 import models.notification._
 import models.store._
 import models._
-import java.time.{ZoneOffset, LocalDateTime, LocalDate}
+import play.api.Configuration
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
 class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
 
-  private val encrypter = new SecureGCMCipherImpl
   private val secretKey = "VqmXp7yigDFxbCUdDdNZVIvbW6RgPNJsliv6swQNCL8="
+  lazy implicit val appConfig: AppConfig = new AppConfig(Configuration("mongodb.encryption.key" -> secretKey))
+  private val encrypter = new SecureGCMCipherImpl
   private val associatedText = "associatedText"
   private val textToEncrypt = "textNotEncrypted"
 
@@ -54,7 +57,7 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
         customerId = None
       )   
 
-      val encryptedModel = sut.encryptFullDisclosure(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptFullDisclosure(model, associatedText)
 
       encryptedModel.userId mustEqual model.userId
       encryptedModel.submissionId mustEqual model.submissionId
@@ -64,7 +67,7 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
       encryptedModel.offshoreLiabilities mustEqual model.offshoreLiabilities
       encryptedModel.otherLiabilities mustEqual model.otherLiabilities
 
-      sut.decryptFullDisclosure(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptFullDisclosure(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a CaseReference" in {
@@ -74,12 +77,12 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
         whatIsTheCaseReference = Some(textToEncrypt)
       ) 
 
-      val encryptedModel = sut.encryptCaseReference(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptCaseReference(model, associatedText)
 
       encryptedModel.doYouHaveACaseReference mustEqual model.doYouHaveACaseReference
       encryptedModel.whatIsTheCaseReference.get.value must not equal model.whatIsTheCaseReference.get
 
-      sut.decryptCaseReference(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptCaseReference(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a ReasonForDisclosingNow" in {
@@ -100,7 +103,7 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
         telephone = Some(textToEncrypt)
       )
 
-      val encryptedModel = sut.encryptReasonForDisclosingNow(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptReasonForDisclosingNow(model, associatedText)
 
       encryptedModel.reason mustEqual model.reason
       encryptedModel.otherReason mustEqual model.otherReason
@@ -116,7 +119,7 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
       encryptedModel.email.get.value must not equal model.email.get
       encryptedModel.telephone.get.value must not equal model.telephone.get
 
-      sut.decryptReasonForDisclosingNow(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptReasonForDisclosingNow(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a full disclosure with onshore liabilities" in {
@@ -205,9 +208,9 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
         customerId = None
       )   
 
-      val encryptedModel = sut.encryptFullDisclosure(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptFullDisclosure(model, associatedText)
       encryptedModel.onshoreLiabilities mustEqual model.onshoreLiabilities
-      sut.decryptFullDisclosure(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptFullDisclosure(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a full disclosure with offshore liabilities" in {
@@ -262,9 +265,9 @@ class FullDisclosureEncrypterSpec extends AnyFreeSpec with Matchers {
         customerId = None
       )   
 
-      val encryptedModel = sut.encryptFullDisclosure(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptFullDisclosure(model, associatedText)
       encryptedModel.onshoreLiabilities mustEqual model.onshoreLiabilities
-      sut.decryptFullDisclosure(encryptedModel, associatedText, secretKey) mustEqual model   
+      sut.decryptFullDisclosure(encryptedModel, associatedText) mustEqual model
     }
 
   }

--- a/test/uk/gov/hmrc/digitaldisclosureservicestore/crypto/NotificationEncrypterSpec.scala
+++ b/test/uk/gov/hmrc/digitaldisclosureservicestore/crypto/NotificationEncrypterSpec.scala
@@ -16,27 +16,30 @@
 
 package crypto
 
+import config.AppConfig
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.freespec.AnyFreeSpec
-
 import models.notification._
 import models.address._
 import models.store.Notification
 import models.{Metadata, YesNoOrUnsure}
-import java.time.{ZoneOffset, LocalDate, LocalDateTime}
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 import models.IncomeOrGainSource
+import play.api.Configuration
 
 class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
 
-  private val encrypter = new SecureGCMCipherImpl
   private val secretKey = "VqmXp7yigDFxbCUdDdNZVIvbW6RgPNJsliv6swQNCL8="
+  lazy implicit val appConfig: AppConfig = new AppConfig(Configuration("mongodb.encryption.key" -> secretKey))
+  private val encrypter = new SecureGCMCipherImpl
   private val associatedText = "associatedText"
   private val textToEncrypt = "textNotEncrypted"
   private val dateToEncrypt = LocalDate.of(2016,1,10)
 
   val sut = new NotificationEncrypter(encrypter)
 
-  val addressToEncrypt = Address(
+  val addressToEncrypt: Address = Address(
     line1 = textToEncrypt,
     line2 = Some(textToEncrypt),
     line3 = Some(textToEncrypt),
@@ -47,7 +50,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
 
   "NotificationEncrypter" - {
     "must encrypt/decrypt an Address" in {
-      val encryptedAddress = sut.encryptAddress(addressToEncrypt, associatedText, secretKey)
+      val encryptedAddress = sut.encryptAddress(addressToEncrypt, associatedText)
 
       encryptedAddress.line1.value must not equal addressToEncrypt.line1
       encryptedAddress.line2.get.value must not equal addressToEncrypt.line2.get
@@ -56,7 +59,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
       encryptedAddress.postcode.get.value must not equal addressToEncrypt.postcode.get
       encryptedAddress.country.value must not equal addressToEncrypt.country.code
 
-      sut.decryptAddress(encryptedAddress, associatedText, secretKey) mustEqual addressToEncrypt
+      sut.decryptAddress(encryptedAddress, associatedText) mustEqual addressToEncrypt
     }
   
     "must encrypt/decrypt an AboutTheEstate" in {
@@ -74,7 +77,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         address = Some(addressToEncrypt)
       )   
 
-      val encryptedAboutTheEstate = sut.encryptAboutTheEstate(aboutTheEstate, associatedText, secretKey)
+      val encryptedAboutTheEstate = sut.encryptAboutTheEstate(aboutTheEstate, associatedText)
 
       encryptedAboutTheEstate.fullName.get.value must not equal aboutTheEstate.fullName.get
       encryptedAboutTheEstate.dateOfBirth.get.value must not equal aboutTheEstate.dateOfBirth.get.toString
@@ -86,7 +89,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
       encryptedAboutTheEstate.registeredForSA.get mustEqual aboutTheEstate.registeredForSA.get
       encryptedAboutTheEstate.sautr.get.value must not equal aboutTheEstate.sautr.get
 
-      sut.decryptAboutTheEstate(encryptedAboutTheEstate, associatedText, secretKey) mustEqual aboutTheEstate
+      sut.decryptAboutTheEstate(encryptedAboutTheEstate, associatedText) mustEqual aboutTheEstate
     }
 
     "must encrypt/decrypt an AboutTheLLP" in {
@@ -96,10 +99,10 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         address = Some(addressToEncrypt)
       ) 
 
-      val encryptedModel = sut.encryptAboutTheLLP(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptAboutTheLLP(model, associatedText)
 
       encryptedModel.name.get.value must not equal model.name.get
-      sut.decryptAboutTheLLP(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptAboutTheLLP(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt an AboutTheTrust" in {
@@ -109,10 +112,10 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         address = Some(addressToEncrypt)
       ) 
 
-      val encryptedModel = sut.encryptAboutTheTrust(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptAboutTheTrust(model, associatedText)
 
       encryptedModel.name.get.value must not equal model.name.get
-      sut.decryptAboutTheTrust(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptAboutTheTrust(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt an AboutTheCompany" in {
@@ -123,11 +126,11 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         address = Some(addressToEncrypt)
       ) 
 
-      val encryptedModel = sut.encryptAboutTheCompany(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptAboutTheCompany(model, associatedText)
 
       encryptedModel.name.get.value must not equal model.name.get
       encryptedModel.registrationNumber.get.value must not equal model.registrationNumber.get
-      sut.decryptAboutTheCompany(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptAboutTheCompany(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt an AboutTheIndividual" in {
@@ -145,7 +148,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         address = Some(addressToEncrypt)
       )   
 
-      val encryptedModel = sut.encryptAboutTheIndividual(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptAboutTheIndividual(model, associatedText)
 
       encryptedModel.fullName.get.value must not equal model.fullName.get
       encryptedModel.dateOfBirth.get.value must not equal model.dateOfBirth.get.toString
@@ -157,7 +160,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
       encryptedModel.registeredForSA.get mustEqual model.registeredForSA.get
       encryptedModel.sautr.get.value must not equal model.sautr.get
 
-      sut.decryptAboutTheIndividual(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptAboutTheIndividual(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt an AboutYou" in {
@@ -178,7 +181,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         address = Some(addressToEncrypt)
       )   
 
-      val encryptedModel = sut.encryptAboutYou(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptAboutYou(model, associatedText)
 
       encryptedModel.fullName.get.value must not equal model.fullName.get
       encryptedModel.telephoneNumber.get.value must not equal model.telephoneNumber.get
@@ -193,7 +196,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
       encryptedModel.registeredForSA.get mustEqual model.registeredForSA.get
       encryptedModel.sautr.get.value must not equal model.sautr.get
 
-      sut.decryptAboutYou(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptAboutYou(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a Background" in {
@@ -210,7 +213,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         otherIncomeSource = Some("Some source")
       )   
 
-      val encryptedModel = sut.encryptBackground(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptBackground(model, associatedText)
 
       encryptedModel.haveYouReceivedALetter mustEqual model.haveYouReceivedALetter
       encryptedModel.letterReferenceNumber mustEqual model.letterReferenceNumber
@@ -223,7 +226,7 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
 
       encryptedModel.organisationName.get.value must not equal model.organisationName.get
 
-      sut.decryptBackground(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptBackground(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a PersonalDetails" in {
@@ -238,8 +241,8 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         aboutTheEstate = Some(AboutTheEstate())
       )   
 
-      val encryptedModel = sut.encryptPersonalDetails(model, associatedText, secretKey)
-      sut.decryptPersonalDetails(encryptedModel, associatedText, secretKey) mustEqual model
+      val encryptedModel = sut.encryptPersonalDetails(model, associatedText)
+      sut.decryptPersonalDetails(encryptedModel, associatedText) mustEqual model
     }
 
     "must encrypt/decrypt a Notification" in {
@@ -254,14 +257,14 @@ class NotificationEncrypterSpec extends AnyFreeSpec with Matchers {
         customerId = None
       )   
 
-      val encryptedModel = sut.encryptNotification(model, associatedText, secretKey)
+      val encryptedModel = sut.encryptNotification(model, associatedText)
 
       encryptedModel.userId mustEqual model.userId
       encryptedModel.submissionId mustEqual model.submissionId
       encryptedModel.lastUpdated mustEqual model.lastUpdated
       encryptedModel.metadata mustEqual model.metadata
 
-      sut.decryptNotification(encryptedModel, associatedText, secretKey) mustEqual model
+      sut.decryptNotification(encryptedModel, associatedText) mustEqual model
     }
 
 


### PR DESCRIPTION
Many of the smaller changes are where I have removed passing of a key through various functions. The key(s) are read from config and do not change, so they can simply be read at the last step.

Here are the various config PRs which have new encrypted `key` values for each environment, and the same `previousKey` value (now encrypted) as this is still needed to decrypt any currently existing data for the next 30 days (the TTL).

- https://github.com/hmrc/app-config-qa/pull/19639
- https://github.com/hmrc/app-config-staging/pull/13544
- https://github.com/hmrc/app-config-production/pull/19392